### PR TITLE
Adds missing includes

### DIFF
--- a/include/mcts/uct.hpp
+++ b/include/mcts/uct.hpp
@@ -1,6 +1,7 @@
 #ifndef MCTS_UCT_HPP
 #define MCTS_UCT_HPP
 
+#include <cmath>
 #include <cassert>
 #include <algorithm>
 #include <memory>

--- a/src/toy_sim.cpp
+++ b/src/toy_sim.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <ctime>
+#include <random>
 #include <mcts/uct.hpp>
 
 template <typename T>


### PR DESCRIPTION
It seems that gcc-6.3.1 includes the files in different order or has more strict checks. I was having compilation errors when I was trying to build mcts.